### PR TITLE
Description must be on a single line

### DIFF
--- a/ac-cider-compliment.el
+++ b/ac-cider-compliment.el
@@ -1,5 +1,4 @@
-;;; ac-cider-compliment.el --- auto-complete sources for Clojure using
-;;; CIDER and compliment
+;;; ac-cider-compliment.el --- Clojure auto-complete sources using CIDER and compliment
 
 ;; Copyright (C) 2012-2014 Alex Yakushev <alex@bytopia.org>
 


### PR DESCRIPTION
Since package.el requires single-line descriptions, this commit makes sure the displayed package description is not truncated in MELPA, the Emacs packages list and elsewhere.
