### PR TITLE
Adds back ac-cider-compliment-symbol-start-pos

### DIFF
--- a/ac-cider-compliment.el
+++ b/ac-cider-compliment.el
@@ -92,6 +92,12 @@ Caches fetched documentation for the current completion call."
                        (cons (substring-no-properties symbol) doc))
           doc)))))
 
+(defun ac-cider-compliment-symbol-start-pos ()
+  "Find the starting position of the symbol at point, unless inside a string."
+  (let ((sap (symbol-at-point)))
+    (when (and sap (not (in-string-p)))
+      (car (bounds-of-thing-at-point 'symbol)))))
+
 (defun ac-cider-compliment-match-everything (prefix candidates)
   candidates)
 


### PR DESCRIPTION
`ac-cider-compliment-symbol-start-pos` was removed fairly recently but is required by the recently resurrected `ac-cider-compliment-popup-doc`. This commit adds it back.
