### PR TITLE
Fixed ac-cider-popup-doc and modified readme.

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,6 +40,13 @@
 (add-hook 'cider-mode-hook 'set-auto-complete-as-completion-at-point-function)
 #+end_src
 
+   You might consider using ac-cider's popup documentation in place of cider-doc: 
+
+#+begin_src el
+(eval-after-load "cider"
+  '(define-key cider-mode-map (kbd "C-c C-d") 'ac-cider-popup-doc))
+#+end_src    
+
 ** Usage
 
    =ac-cider= should now automatically be enabled when you visit a buffer in
@@ -49,3 +56,4 @@
    Simply trigger auto-completion, and completion candidates supplied by CIDER
    should be displayed. After a short delay, popup documentation for the
    completed symbol should also be displayed.
+      

--- a/ac-cider.el
+++ b/ac-cider.el
@@ -81,7 +81,7 @@ Caches fetched documentation for the current completion call."
                 (substring-no-properties
                  (replace-regexp-in-string
                   "\r" ""
-                  (plist-get (nrepl-send-sync-request
+                  (plist-get (nrepl-send-request-sync
                               (list "op" "complete-doc"
                                     "session" (nrepl-current-session)
                                     "ns" nrepl-buffer-ns


### PR DESCRIPTION
The function `nrepl-send-sync-request` is renamed into `nrepl-send-request-sync` in cider 0.7.0

https://github.com/clojure-emacs/cider/blob/v0.7.0/nrepl-client.el#L723-744

And maybe some one want to use `ac-cider-popup-doc` to popup doc instead of `cider-doc`, so i modified the readme.
