### PR TITLE
Use cider-current-ns in case nrepl-buffer-ns is nil

### DIFF
--- a/ac-cider.el
+++ b/ac-cider.el
@@ -84,7 +84,7 @@ Caches fetched documentation for the current completion call."
                   (nrepl-dict-get (nrepl-send-sync-request
                                    (list "op" "complete-doc"
                                          "session" (nrepl-current-session)
-                                         "ns" nrepl-buffer-ns
+                                         "ns" (cider-current-ns)
                                          "symbol" symbol))
                                   "completion-doc"))))
                (doc (if (string= "\"\"" doc)


### PR DESCRIPTION
In my environment, emacs always freezes after auto-complete popup shows. And after seconds it shows error message.

```
Error running timer `ac-quick-help': (error "Sync nREPL request timed out (op complete-doc session 1def0d59-175a-4963-a5e2-1c93f2088e07 ns nil symbol do id 59)")
```

I think the cause is that `nrepl-buffer-ns` is `nil`(see the code changes).
Using `cider-current-ns` instead of `nrepl-buffer-ns` fixes the issue.
