### PR TITLE
Use default match function

### DIFF
--- a/ac-cider.el
+++ b/ac-cider.el
@@ -94,9 +94,6 @@ Caches fetched documentation for the current completion call."
                        (cons (substring-no-properties symbol) doc))
           doc)))))
 
-(defun ac-cider-match-everything (prefix candidates)
-  candidates)
-
 ;;;###autoload
 (defface ac-cider-candidate-face
   '((t (:inherit ac-candidate-face)))
@@ -115,7 +112,6 @@ Caches fetched documentation for the current completion call."
     (candidate-face . ac-cider-candidate-face)
     (selection-face . ac-cider-selection-face)
     (prefix . cider-completion-symbol-start-pos)
-    (match . ac-cider-match-everything)
     (document . ac-cider-documentation)
     (cache))
   "Defaults common to the various completion sources.")


### PR DESCRIPTION
With `ac-cider-match-everything`, auto-complete doesn't filter candidates correctly.

![screenshot 2014-09-26 12 16 22](https://cloud.githubusercontent.com/assets/356330/4415484/fd8ce9d0-452b-11e4-849b-f70b0e38b5a4.png)

This screenshot describes the problem. After the first 2 characters input(`cl`), auto-complete displayed candidates and did not update candidates with subsequent inputs.

The cause is that  `ac-cider-match-everything` just returns `candidates`.
 If `match` isn't specified, auto-complete internally uses `all-completions` function for the match function, which works perfectly.
