### PR TITLE
To work with latest cider

### DIFF
--- a/ac-cider.el
+++ b/ac-cider.el
@@ -85,7 +85,7 @@ Caches fetched documentation for the current completion call."
                 (substring-no-properties
                  (replace-regexp-in-string
                   "\r" ""
-                  (nrepl-dict-get (nrepl-send-sync-request
+                  (nrepl-dict-get (cider-nrepl-send-sync-request
                                    (list "op" "complete-doc"
                                          "session" (nrepl-current-session)
                                          "ns" (cider-current-ns)


### PR DESCRIPTION
`nrepl-send-sync-request` is renamed to  `cider-nrepl-send-sync-request` in latest cider.