### PR TITLE
The complete-doc command updated to use cider-current-session

### DIFF
--- a/ac-cider.el
+++ b/ac-cider.el
@@ -87,7 +87,7 @@ Caches fetched documentation for the current completion call."
                   "\r" ""
                   (nrepl-dict-get (cider-nrepl-send-sync-request
                                    (list "op" "complete-doc"
-                                         "session" (nrepl-current-session)
+                                         "session" (cider-current-session)
                                          "ns" (cider-current-ns)
                                          "symbol" symbol))
                                   "completion-doc"))))


### PR DESCRIPTION
...and as of some time in 0.11.0-SNAPSHOT of cider, this caused complete-doc to fail.