### PR TITLE
[Fix #33] Autocomplete fails when nREPL not connected

### DIFF
--- a/ac-cider.el
+++ b/ac-cider.el
@@ -71,7 +71,8 @@
 (defun ac-cider-candidates-everything ()
   "Return all candidates for a symbol at point."
   (setq ac-cider-documentation-cache nil)
-  (cider-complete ac-prefix))
+  (when (cider-connected-p)
+    (cider-complete ac-prefix)))
 
 (defun ac-cider-documentation (symbol)
   "Return documentation for the given SYMBOL, if available.


### PR DESCRIPTION
Before completing words, check nREPL connection first.