### PR TITLE
Optionally show namespaces of candidates in popup menu

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,6 +31,13 @@
      (add-to-list 'ac-modes 'cider-repl-mode)))
 #+end_src
 
+   By default, entries in the popup menu will also display the namespace that
+   the symbol belongs to. To disable this behavior, add to your init file:
+
+#+begin_src el
+(setq ac-cider-show-ns nil)
+#+end_src
+
    If you want to trigger auto-complete using TAB in CIDER buffers, add this to
    your configuration file (but note that it is incompatible with =(setq
    tab-always-indent 'complete)=):

--- a/ac-cider.el
+++ b/ac-cider.el
@@ -46,6 +46,11 @@
 ;;          (add-to-list 'ac-modes 'cider-mode)
 ;;          (add-to-list 'ac-modes 'cider-repl-mode)))
 
+;; By default, entries in the popup menu will also display the namespace that
+;; the symbol belongs to. To disable this behavior, add to your init file:
+
+;;     (setq ac-cider-show-ns nil)
+
 ;; If you want to trigger auto-complete using TAB in CIDER buffers, add this to
 ;; your configuration file, but note that it is incompatible with (setq
 ;; tab-always-indent 'complete):
@@ -68,11 +73,35 @@
 
 (defvar ac-cider-documentation-cache '())
 
+;; customization group
+(defgroup ac-cider nil
+  "auto-complete sources for cider."
+  :prefix "ac-cider-"
+  :group 'completion)
+
+(defcustom ac-cider-show-ns t
+  "Non-nil means rows in the AC popup menu will show the namespace of the item."
+  :type 'boolean
+  :group 'ac-cider)
+
+(defun ac-cider-prepare-candidates (candidates)
+  "Apply changes for auto-complete to the candidates returned from cider-complete."
+  (if ac-cider-show-ns
+      (mapcar
+       (lambda (candidate)
+         (let ((ns (get-text-property 0 'ns candidate)))
+           ;; Copy the 'ns' value to 'summary' for auto-complete to display
+           (when ns
+             (add-text-properties 0 1 `(summary ,ns) candidate))
+           candidate))
+       candidates)
+    candidates))
+
 (defun ac-cider-candidates-everything ()
   "Return all candidates for a symbol at point."
   (setq ac-cider-documentation-cache nil)
   (when (cider-connected-p)
-    (cider-complete ac-prefix)))
+    (ac-cider-prepare-candidates (cider-complete ac-prefix))))
 
 (defun ac-cider-documentation (symbol)
   "Return documentation for the given SYMBOL, if available.


### PR DESCRIPTION
This matches the menu from the cider company-mode backend.
[screenshot](http://i.imgur.com/MbT6sAC.png)
